### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "markdown-it": "^12.3.2",
         "mqtt": "^4.3.7",
         "request": "^2.88.2",
-        "source-map-support": "^0.5.16"
+        "source-map-support": "^0.5.16",
+        "express-rate-limit": "^8.3.2"
     },
     "preferGlobal": true,
     "devDependencies": {

--- a/src/web-server.ts
+++ b/src/web-server.ts
@@ -4,9 +4,14 @@ import { conf } from './utils'
 import fs = require('fs')
 import express = require('express')
 import markdownIt = require('markdown-it')
+import rateLimit = require('express-rate-limit')
 
 // a web-server
 const app = express()
+const readmeLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100,
+})
 
 // set the route: raw api
 app.get('/api/*', (req, res) => {
@@ -80,7 +85,7 @@ app.get('/intrusion_settings', (_, res) => {
 })
 
 // set the route: returns the readme.md as default page
-app.get('*', (_, res) => {
+app.get('*', readmeLimiter, (_, res) => {
     fs.readFile('README.md', 'utf8', (_, data) => {
         res.send(markdownIt().render(data.toString()))
     })


### PR DESCRIPTION
Potential fix for [https://github.com/ycardon/gigaset-elements-proxy/security/code-scanning/2](https://github.com/ycardon/gigaset-elements-proxy/security/code-scanning/2)

Add Express rate-limiting middleware and apply it to the catch-all README route (or globally).  
Best minimal-change fix: use `express-rate-limit` and attach a limiter specifically to `app.get('*', ...)` so existing API behavior is preserved while preventing abuse of the filesystem-backed endpoint.

In `src/web-server.ts`:
1. Add an import for `express-rate-limit`.
2. Define a limiter instance near app setup (for example 100 requests per 15 minutes).
3. Apply that limiter as middleware on the `'*'` route before the handler.

This preserves functionality (still serves rendered README) while limiting request bursts that trigger `fs.readFile`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
