### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/dist/web-server.js
+++ b/dist/web-server.js
@@ -6,8 +6,13 @@ const utils_1 = require("./utils");
 const fs = require("fs");
 const express = require("express");
 const markdownIt = require("markdown-it");
+const rateLimit = require("express-rate-limit");
 // a web-server
 const app = express();
+const readmeLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 100
+});
 // set the route: raw api
 app.get('/api/*', (req, res) => {
     gigaset_1.gigasetRequest.get(gigaset_1.GIGASET_URL.BASE + req.url).pipe(res);
@@ -76,7 +81,7 @@ app.get('/intrusion_settings', (_, res) => {
     });
 });
 // set the route: returns the readme.md as default page
-app.get('*', (_, res) => {
+app.get('*', readmeLimiter, (_, res) => {
     fs.readFile('README.md', 'utf8', (_, data) => {
         res.send(markdownIt().render(data.toString()));
     });


### PR DESCRIPTION
Potential fix for [https://github.com/ycardon/gigaset-elements-proxy/security/code-scanning/1](https://github.com/ycardon/gigaset-elements-proxy/security/code-scanning/1)

Add an Express rate-limiting middleware and apply it to the expensive catch-all route that reads and renders the README.

Best minimal fix (without changing existing behavior):  
1. Import `express-rate-limit` in `dist/web-server.js`.  
2. Define a limiter instance (for example, 100 requests per 15 minutes per IP).  
3. Attach that limiter specifically to `app.get('*', ...)` by inserting it as middleware before the handler.

This keeps all existing route logic intact while preventing high-frequency abuse of the filesystem/markdown-render path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
